### PR TITLE
fix zip dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        toolchain: 
-          - "1.73"  # MSRV
+        toolchain:
+          - "1.75"  # MSRV
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.37", features = ["encoding"] }
-zip = { version = "2.6", default-features = false, features = ["deflate"] }
+zip = { version = "3.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.37", features = ["encoding"] }
-zip = { version = "3.0", default-features = false, features = ["deflate"] }
+zip = { version = "4.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }


### PR DESCRIPTION
see https://github.com/tafia/calamine/pull/506

Will temporarily create a renamed fork named `qsv-calamine` so qsv can be published  to crates.io.

Once https://github.com/tafia/calamine/pull/506 is merged and a new calamine release is made, will revert back from `qsv-calamine` to `calamine`